### PR TITLE
Fixing `dotnet run` execution failure

### DIFF
--- a/SimplifiedLottery.ConsoleUi/Program.cs
+++ b/SimplifiedLottery.ConsoleUi/Program.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.IO;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -32,6 +35,11 @@ namespace SimplifiedLottery.ConsoleUi
 		private static IHost CreateHost(string[] args)
 		{
 			var hostBuilder = Host.CreateDefaultBuilder(args);
+			hostBuilder.ConfigureAppConfiguration(builder =>
+			{
+				var exePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)??Directory.GetCurrentDirectory();
+				builder.AddJsonFile(Path.Combine(exePath, "appsettings.json"));
+			});
 			hostBuilder.ConfigureServices((context, services) =>
 			{
 				services.Configure<IntegerPlayerServiceOptions>(

--- a/SimplifiedLottery.ConsoleUi/SimplifiedLottery.ConsoleUi.csproj
+++ b/SimplifiedLottery.ConsoleUi/SimplifiedLottery.ConsoleUi.csproj
@@ -8,6 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
@@ -15,12 +21,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SimplifiedLottery.Core\SimplifiedLottery.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Changed appsettings type to "content", retaining the "copy always"
* Added section to ensure `appsettings.config` is loaded from same location as the program binaries
